### PR TITLE
Fixing a lua error

### DIFF
--- a/lua/patchprotect/server/cleanup.lua
+++ b/lua/patchprotect/server/cleanup.lua
@@ -93,7 +93,7 @@ function sv_PProtect.Cleanup( typ, ply )
 
 end
 net.Receive( "pprotect_cleanup", sv_PProtect.Cleanup )
-concommand.Add( "gmod_admin_cleanup", function( ply, cmd, args ) sv_PProtect.Cleanup( "all" ) end )
+concommand.Add( "gmod_admin_cleanup", function( ply, cmd, args ) sv_PProtect.Cleanup( "all", ply ) end )
 
 
 


### PR DESCRIPTION
When running gmod_admin_cleanup:
[ERROR] addons/PatchProtect/lua/patchprotect/server/cleanup.lua:43: attempt to index local 'ply' (a nil value